### PR TITLE
Update __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@ def _safe_import(lib):
 
 _imageio        = _safe_import('imageio')
 _libm2k         = _safe_import('libm2k')
-_visa           = _safe_import('visa')
+_visa           = _safe_import('pyvisa')
 _serial         = _safe_import('serial')
 _minimalmodbus  = _safe_import('minimalmodbus')
 _sounddevice    = _safe_import('sounddevice')


### PR DESCRIPTION
Brandon figured this out. Changed module reference from `visa` to `pyvisa`. Necessary to run on new installs. Works great on the Sat Spec machine as of right now.
BTW, the newest version of the R&S drivers doesn't work, but version 5.12.10 does.